### PR TITLE
Add Nextcloud storage and model versioning

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,12 +40,23 @@ model Model {
   author      User?     @relation("UserModels", fields: [authorId], references: [id])
   sphere      Sphere?
   logs        Log[]
+  versions    ModelVersion[]
   markedForDeletion Boolean @default(false)
   markedById  String?
   markedBy    User?     @relation("MarkedForDeletion", fields: [markedById], references: [id])
   markedAt    DateTime?
   deletionComment String?
   projects    Project[] @relation("ModelProjects") // Многие-ко-многим
+}
+
+model ModelVersion {
+  id        String   @id @default(uuid())
+  version   String
+  fileUrl   String
+  images    String[]
+  createdAt DateTime @default(now())
+  modelId   String
+  model     Model    @relation(fields: [modelId], references: [id])
 }
 
 model Project {

--- a/src/app/api/models/[id]/route.js
+++ b/src/app/api/models/[id]/route.js
@@ -25,6 +25,7 @@ export async function GET(request, { params }) {
       include: {
         author: true,
         projects: true,
+        versions: true,
         logs: {
           include: {
             user: true,

--- a/src/components/ModelCard.jsx
+++ b/src/components/ModelCard.jsx
@@ -26,6 +26,11 @@ export const ModelCard = ({ model, onDeleteRequest, projectId }) => {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [user, setUser] = useState();
+  const [selectedVersion, setSelectedVersion] = useState(
+    model.versions && model.versions.length > 0
+      ? model.versions[model.versions.length - 1]
+      : { fileUrl: model.fileUrl, images: model.images, version: 'Последняя' }
+  );
   
   useEffect(() => {
     const load = async () =>
@@ -41,7 +46,7 @@ export const ModelCard = ({ model, onDeleteRequest, projectId }) => {
   const handleDownload = async () => {
     setIsDownloading(true);
     try {
-      const response = await fetch(model.fileUrl);
+      const response = await fetch(selectedVersion.fileUrl);
       const blob = await response.blob();
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -68,14 +73,14 @@ export const ModelCard = ({ model, onDeleteRequest, projectId }) => {
   };
 
   const nextImage = () => {
-    setCurrentImageIndex((prev) => 
-      prev === model.images.length - 1 ? 0 : prev + 1
+    setCurrentImageIndex((prev) =>
+      prev === selectedVersion.images.length - 1 ? 0 : prev + 1
     );
   };
 
   const prevImage = () => {
-    setCurrentImageIndex((prev) => 
-      prev === 0 ? model.images.length - 1 : prev - 1
+    setCurrentImageIndex((prev) =>
+      prev === 0 ? selectedVersion.images.length - 1 : prev - 1
     );
   };
 
@@ -143,11 +148,11 @@ export const ModelCard = ({ model, onDeleteRequest, projectId }) => {
       <div className="p-6 text-gray-800">
         <h1 className="text-2xl pb-4 font-bold text-gray-800">{model.title}</h1>
         {/* Галерея изображений */}
-        {model.images?.length > 0 && (
+        {selectedVersion.images?.length > 0 && (
           <div className="mb-6">
             <div className="flex space-x-4 overflow-x-auto pb-2">
-              {model.images.map((image, index) => (
-                <div 
+              {selectedVersion.images.map((image, index) => (
+                <div
                   key={index}
                   className="relative flex-shrink-0 w-64 h-48 cursor-pointer"
                   onClick={() => openModal(index)}
@@ -178,7 +183,7 @@ export const ModelCard = ({ model, onDeleteRequest, projectId }) => {
               
               <div className="relative h-[70vh] w-full">
                 <Image
-                  src={model.images[currentImageIndex]}
+                  src={selectedVersion.images[currentImageIndex]}
                   alt={`${model.title} - изображение ${currentImageIndex + 1}`}
                   fill
                   className="object-contain"
@@ -187,7 +192,7 @@ export const ModelCard = ({ model, onDeleteRequest, projectId }) => {
               
               <div className="flex justify-between items-center pb-6 ml-10 mr-10">
                 <div className="flex space-x-2">
-                  {model.images.map((_, index) => (
+                  {selectedVersion.images.map((_, index) => (
                     <div 
                       key={index}
                       className={`h-2 w-2 rounded-full ${index === currentImageIndex ? 'bg-blue-600' : 'bg-blue-300'}`}
@@ -264,6 +269,24 @@ export const ModelCard = ({ model, onDeleteRequest, projectId }) => {
         {/* кнопки */}
         <div className="flex justify-between items-start mb-6">
           <div className="flex space-x-2">
+
+            {model.versions?.length > 0 && (
+              <select
+                value={selectedVersion.version}
+                onChange={(e) => {
+                  const ver = model.versions.find(v => v.version === e.target.value);
+                  if (ver) {
+                    setSelectedVersion(ver);
+                    setCurrentImageIndex(0);
+                  }
+                }}
+                className="px-2 py-1 border rounded text-sm"
+              >
+                {model.versions.map(v => (
+                  <option key={v.id} value={v.version}>{v.version}</option>
+                ))}
+              </select>
+            )}
             
             {checkPermission(user, 'download_models') && (
               <button

--- a/src/components/ModelEditForm.jsx
+++ b/src/components/ModelEditForm.jsx
@@ -9,6 +9,7 @@ export default function ModelEditForm({ id, userRole }) {
     title: '',
     description: '',
     authorId: '',
+    version: '',
     sphere: '',
   })
   const [selectedProjects, setSelectedProjects] = useState([])
@@ -71,6 +72,7 @@ export default function ModelEditForm({ id, userRole }) {
           title: data.title || '',
           description: data.description || '',
           authorId: data.authorId || '',
+          version: '',
           sphere: data.sphere || '',
         })
         
@@ -222,16 +224,30 @@ export default function ModelEditForm({ id, userRole }) {
             <label className="block text-sm font-medium text-gray-700 mb-1">
               Название модели <span className="text-red-500">*</span>
             </label>
-            <input
-              name="title"
-              value={form.title}
-              onChange={handleChange}
-              className={`block w-full px-3 py-2 border ${canEditModel ? 'border-gray-300' : 'border-gray-100 bg-gray-50'} rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500`}
-              required
-              maxLength={50}
-              disabled={canEditDescription}
-            />
-          </div>
+          <input
+            name="title"
+            value={form.title}
+            onChange={handleChange}
+            className={`block w-full px-3 py-2 border ${canEditModel ? 'border-gray-300' : 'border-gray-100 bg-gray-50'} rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500`}
+            required
+            maxLength={50}
+            disabled={canEditDescription}
+          />
+        </div>
+
+        {/* Версия */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Версия
+          </label>
+          <input
+            name="version"
+            value={form.version}
+            onChange={handleChange}
+            className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            maxLength={20}
+          />
+        </div>
 
           {/* Текущие скриншоты */}
           <div className="col-span-2">

--- a/src/lib/fileStorage.js
+++ b/src/lib/fileStorage.js
@@ -1,26 +1,56 @@
 // src/lib/fileStorage.js
 import fs from 'fs/promises';
 import path from 'path';
+import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 
 const UPLOADS_DIR = path.join(process.cwd(), 'public', 'uploads');
 
-export async function saveFile(file, subfolder = 'models') {
-  try {
-    // Создаем директории, если их нет
-    const uploadDir = path.join(UPLOADS_DIR, subfolder);
-    await fs.mkdir(uploadDir, { recursive: true });
+function getNextcloudConfig() {
+  const url = process.env.NEXTCLOUD_URL;
+  const username = process.env.NEXTCLOUD_ADMIN_USER;
+  const password = process.env.NEXTCLOUD_ADMIN_PASSWORD;
+  if (url && username && password) {
+    return { url, username, password };
+  }
+  return null;
+}
 
-    // Генерируем уникальное имя файла
+export async function saveFile(file, subfolder = 'models') {
+  const nextcloud = getNextcloudConfig();
+  try {
     const fileExt = path.extname(file.name);
     const fileName = `${uuidv4()}${fileExt}`;
-    const filePath = path.join(uploadDir, fileName);
 
-    // Сохраняем файл
+    if (nextcloud) {
+      const { url, username, password } = nextcloud;
+      const folderUrl = `${url}/remote.php/dav/files/${username}/${subfolder}`;
+      try {
+        await axios.request({
+          method: 'MKCOL',
+          url: folderUrl,
+          auth: { username, password },
+          headers: { 'OCS-APIRequest': 'true' }
+        });
+      } catch (err) {
+        if (err.response?.status !== 405) throw err;
+      }
+
+      const uploadUrl = `${folderUrl}/${fileName}`;
+      const buffer = Buffer.from(await file.arrayBuffer());
+      await axios.put(uploadUrl, buffer, {
+        auth: { username, password },
+        headers: { 'OCS-APIRequest': 'true', 'Content-Type': file.type || 'application/octet-stream' }
+      });
+      return uploadUrl;
+    }
+
+    // Локальное хранение если нет конфигурации Nextcloud
+    const uploadDir = path.join(UPLOADS_DIR, subfolder);
+    await fs.mkdir(uploadDir, { recursive: true });
+    const filePath = path.join(uploadDir, fileName);
     const buffer = Buffer.from(await file.arrayBuffer());
     await fs.writeFile(filePath, buffer);
-
-    // Возвращаем относительный путь для доступа через веб
     return `/uploads/${subfolder}/${fileName}`;
   } catch (err) {
     console.error('File save error:', err);
@@ -29,8 +59,19 @@ export async function saveFile(file, subfolder = 'models') {
 }
 
 export async function deleteFile(filePath) {
+  const nextcloud = getNextcloudConfig();
   try {
     if (!filePath) return;
+
+    if (nextcloud && filePath.startsWith(nextcloud.url)) {
+      const { username, password } = nextcloud;
+      await axios.delete(filePath, {
+        auth: { username, password },
+        headers: { 'OCS-APIRequest': 'true' }
+      });
+      return;
+    }
+
     const fullPath = path.join(process.cwd(), 'public', filePath);
     await fs.unlink(fullPath);
   } catch (err) {
@@ -41,25 +82,26 @@ export async function deleteFile(filePath) {
 
 export async function deleteModelFiles(fileUrl) {
   if (!fileUrl) return;
-  
+
   try {
     // Удаляем основной файл
     await deleteFile(fileUrl);
-    
-    // Удаляем связанные файлы (если есть)
-    const baseName = path.basename(fileUrl, path.extname(fileUrl));
-    const dirPath = path.join(process.cwd(), 'public', path.dirname(fileUrl));
-    
-    try {
-      const files = await fs.readdir(dirPath);
-      await Promise.all(
-        files
-          .filter(file => file.startsWith(baseName))
-          .map(file => deleteFile(path.join(path.dirname(fileUrl), file)))
-        )
-    } catch (err) {
-      // Если директории нет - игнорируем ошибку
-      if (err.code !== 'ENOENT') throw err;
+
+    const nextcloud = getNextcloudConfig();
+
+    if (!nextcloud || !fileUrl.startsWith(nextcloud.url)) {
+      const baseName = path.basename(fileUrl, path.extname(fileUrl));
+      const dirPath = path.join(process.cwd(), 'public', path.dirname(fileUrl));
+      try {
+        const files = await fs.readdir(dirPath);
+        await Promise.all(
+          files
+            .filter(file => file.startsWith(baseName))
+            .map(file => deleteFile(path.join(path.dirname(fileUrl), file)))
+        );
+      } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+      }
     }
   } catch (error) {
     console.error('Ошибка удаления файлов модели:', error);


### PR DESCRIPTION
## Summary
- support Nextcloud in `fileStorage` library
- add `ModelVersion` schema and include versions in model API
- upload and update routes now store files in Nextcloud and create versions
- add version support in model upload/edit forms
- show version selector in model card

## Testing
- `npm install` *(fails: binaries.prisma.sh blocked)*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6858f12067e8832c835b353dc6fc83ae