### PR TITLE
Add versioned storage on Nextcloud

### DIFF
--- a/src/app/api/models/update/route.js
+++ b/src/app/api/models/update/route.js
@@ -1,7 +1,7 @@
 // app/api/models/update/route.js
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
-import { saveFile, deleteFile } from '@/lib/fileStorage'
+import { saveModelFile, deleteFile } from '@/lib/fileStorage'
 import { getUserFromSession } from '@/lib/auth'
 
 export async function POST(request) {
@@ -113,7 +113,7 @@ export async function POST(request) {
       if (existingModel.fileUrl) {
         await deleteFile(existingModel.fileUrl)
       }
-      updateData.fileUrl = await saveFile(zipFile, 'models')
+      updateData.fileUrl = await saveModelFile(zipFile, id, version || 'current')
       changes.push('Обновлён файл модели')
     }
 
@@ -121,7 +121,7 @@ export async function POST(request) {
     const screenshots = formData.getAll('screenshots')
     if (screenshots.length > 0) {
       const newScreenshots = await Promise.all(
-        screenshots.map(file => saveFile(file, 'models/screenshots'))
+        screenshots.map(file => saveModelFile(file, id, version || 'current', true))
       )
       
       // Получаем текущие изображения (уже без удаленных)

--- a/src/app/api/models/upload/route.js
+++ b/src/app/api/models/upload/route.js
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid'
-import { saveFile } from '@/lib/fileStorage'
+import { saveModelFile } from '@/lib/fileStorage'
 import { prisma } from '@/lib/prisma'
 import { getUserFromSession } from '@/lib/auth'
 
@@ -37,12 +37,12 @@ export async function POST(request) {
 
     const modelId = uuidv4()
 
-    const fileUrl = await saveFile(zipFile, 'models')
+    const fileUrl = await saveModelFile(zipFile, modelId, version)
 
     const imageUrls = []
     for (const file of screenshots) {
       if (!file || typeof file.arrayBuffer !== 'function') continue
-      const url = await saveFile(file, 'models/screenshots')
+      const url = await saveModelFile(file, modelId, version, true)
       imageUrls.push(url)
     }
 

--- a/src/lib/fileStorage.js
+++ b/src/lib/fileStorage.js
@@ -16,6 +16,12 @@ function getNextcloudConfig() {
   return null;
 }
 
+export function modelSubfolder(modelId, version, isScreenshot = false) {
+  const parts = ['models', String(modelId), `v${version}`]
+  if (isScreenshot) parts.push('screenshots')
+  return parts.join('/')
+}
+
 export async function saveFile(file, subfolder = 'models') {
   const nextcloud = getNextcloudConfig();
   try {
@@ -56,6 +62,11 @@ export async function saveFile(file, subfolder = 'models') {
     console.error('File save error:', err);
     throw err;
   }
+}
+
+export async function saveModelFile(file, modelId, version, isScreenshot = false) {
+  const folder = modelSubfolder(modelId, version, isScreenshot)
+  return saveFile(file, folder)
 }
 
 export async function deleteFile(filePath) {


### PR DESCRIPTION
## Summary
- keep version folders when storing files on Nextcloud
- save uploaded models and screenshots using versioned folders
- update model update endpoint to use Nextcloud versioned paths

## Testing
- `npm install`
- `CI=true npm run lint` *(fails: asked how to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6858f6dcf734832c9103a2ad49127693