### PR TITLE
Refactor utilities

### DIFF
--- a/src/components/ModelCard.jsx
+++ b/src/components/ModelCard.jsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation'
+import { formatDateTime } from '@/lib/utils'
 import { checkAnyPermission, checkPermission } from '@/lib/permission'
 // import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
@@ -114,15 +115,6 @@ export const ModelCard = ({ model, onDeleteRequest, projectId }) => {
     }
   };
 
-  const formatDateTime = (dateString) => {
-    const date = new Date(dateString);
-    const day = date.getDate().toString().padStart(2, '0');
-    const month = (date.getMonth() + 1).toString().padStart(2, '0');
-    const year = date.getFullYear();
-    const hours = date.getHours().toString().padStart(2, '0');
-    const minutes = date.getMinutes().toString().padStart(2, '0');
-    return `${day}.${month}.${year} ${hours}:${minutes}`;
-  };
 
   return (
     <div className="w-full mx-auto rounded-lg overflow-hidden">

--- a/src/components/ModelEditForm.jsx
+++ b/src/components/ModelEditForm.jsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { formatFileSize } from '@/lib/utils'
 import { checkPermission } from '@/lib/permission'
 
 export default function ModelEditForm({ id, userRole }) {
@@ -131,13 +132,6 @@ export default function ModelEditForm({ id, userRole }) {
     })
   }
 
-  const formatFileSize = (bytes) => {
-    if (!bytes) return '0 Bytes'
-    const k = 1024
-    const sizes = ['Bytes', 'KB', 'MB', 'GB']
-    const i = Math.floor(Math.log(bytes) / Math.log(k))
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
-  }
 
   const handleSubmit = async (e) => {
   e.preventDefault()

--- a/src/components/ModelUploadForm.jsx
+++ b/src/components/ModelUploadForm.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useEffect } from 'react'
+import { formatFileSize } from '@/lib/utils'
 
 export default function ModelUploadForm() {
   const [loading, setLoading] = useState(false)
@@ -140,14 +141,6 @@ export default function ModelUploadForm() {
     }
   };
 
-  // Форматирование размера файла
-  const formatFileSize = (bytes) => {
-    if (bytes === 0) return '0 Bytes'
-    const k = 1024
-    const sizes = ['Bytes', 'KB', 'MB', 'GB']
-    const i = Math.floor(Math.log(bytes) / Math.log(k))
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
-  }
 
   const filteredProjects = projects.filter(project =>
     project.name.toLowerCase().includes(projectSearchTerm.toLowerCase()))

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,17 @@
+export function formatFileSize(bytes) {
+  if (!bytes) return '0 Bytes'
+  const k = 1024
+  const sizes = ['Bytes', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
+}
+
+export function formatDateTime(dateString) {
+  const date = new Date(dateString)
+  const day = String(date.getDate()).padStart(2, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const year = date.getFullYear()
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${day}.${month}.${year} ${hours}:${minutes}`
+}


### PR DESCRIPTION
## Summary
- centralize common `formatDateTime` and `formatFileSize` helpers in `src/lib/utils.js`
- reuse utilities in model forms and cards

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685902548f44832cb997888cf76d6efb