### PR TITLE
Remove Nextcloud folder on model delete

### DIFF
--- a/src/app/api/models/[id]/route.js
+++ b/src/app/api/models/[id]/route.js
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma'
 import { getUserFromSession } from '@/lib/auth'
 import { deleteFile } from '@/lib/fileStorage'
 import { logModelAction } from '@/lib/logger'
+import { deleteFolderRecursive, sanitizeName } from '@/lib/nextcloud'
 
 export async function GET(request, { params }) {
   
@@ -146,6 +147,7 @@ export async function DELETE(request, { params }) {
       // Обнуляем ссылки на модель в логах, чтобы сохранить историю
       await prisma.log.updateMany({ where: { modelId: id }, data: { modelId: null } });
       await prisma.model.delete({ where: { id } });
+      await deleteFolderRecursive(`models/${sanitizeName(model.title)}`);
 
       await logModelAction(
         `Модель удалена (${model.title})`,

--- a/src/lib/nextcloud.js
+++ b/src/lib/nextcloud.js
@@ -36,6 +36,21 @@ export async function createFolderRecursive(folder) {
   }
 }
 
+export async function deleteFolderRecursive(folder) {
+  const cfg = getConfig()
+  if (!cfg) return
+  const { url, username, password } = cfg
+  const folderUrl = `${url}/remote.php/dav/files/${username}/${folder}`
+  try {
+    await axios.delete(folderUrl, {
+      auth: { username, password },
+      headers: { 'OCS-APIRequest': 'true' }
+    })
+  } catch (err) {
+    if (err.response?.status !== 404) throw err
+  }
+}
+
 async function renameFolder(oldPath, newPath) {
   const cfg = getConfig()
   if (!cfg) return
@@ -165,5 +180,6 @@ export async function syncModelFolder(model, oldTitle = null) {
 export default {
   syncModelFolder,
   sanitizeName,
-  createFolderRecursive
+  createFolderRecursive,
+  deleteFolderRecursive
 }


### PR DESCRIPTION
## Summary
- add helper to delete folders in Nextcloud
- remove model folders from Nextcloud when deleting models

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3124c3d8832cb7b0fb2a883e2c8f