### PR TITLE
Fix preview autoplay

### DIFF
--- a/src/app/dashboard/logs/page.js
+++ b/src/app/dashboard/logs/page.js
@@ -155,7 +155,7 @@ export default function LogsPage() {
   }
 
   const handleMouseEnter = (model, event) => {
-    
+
     console.log(models)
     const currentModel = models.find(item => item.id === model?.id);
     if (currentModel?.images?.length > 0) {
@@ -168,7 +168,6 @@ export default function LogsPage() {
       setPreviewModel(currentModel)
       setCurrentImageIndex(0)
       setShowPreview(true)
-      startAutoPlay()
     }
     else
     {
@@ -181,6 +180,17 @@ export default function LogsPage() {
     setPreviewModel(null)
     stopAutoPlay()
   }
+
+  useEffect(() => {
+    if (showPreview && previewModel?.images?.length) {
+      startAutoPlay()
+    } else {
+      stopAutoPlay()
+    }
+    return () => {
+      stopAutoPlay()
+    }
+  }, [previewModel, showPreview])
   useEffect(() => {
     return () => {
       if (autoPlayInterval) {

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -193,7 +193,6 @@ export default function DashboardPage() {
       setPreviewModel(model)
       setCurrentImageIndex(0)
       setShowPreview(true)
-      startAutoPlay()
     }
   }
   
@@ -202,6 +201,17 @@ export default function DashboardPage() {
     setPreviewModel(null)
     stopAutoPlay()
   }
+
+  useEffect(() => {
+    if (showPreview && previewModel?.images?.length) {
+      startAutoPlay()
+    } else {
+      stopAutoPlay()
+    }
+    return () => {
+      stopAutoPlay()
+    }
+  }, [previewModel, showPreview])
   useEffect(() => {
     return () => {
       if (autoPlayInterval) {

--- a/src/app/dashboard/projects/[id]/page.js
+++ b/src/app/dashboard/projects/[id]/page.js
@@ -217,7 +217,6 @@ export default function ProjectPage({ params }) {
       setPreviewModel(model)
       setCurrentImageIndex(0)
       setShowPreview(true)
-      startAutoPlay()
     }
   }
   
@@ -226,6 +225,17 @@ export default function ProjectPage({ params }) {
     setPreviewModel(null)
     stopAutoPlay()
   }
+
+  useEffect(() => {
+    if (showPreview && previewModel?.images?.length) {
+      startAutoPlay()
+    } else {
+      stopAutoPlay()
+    }
+    return () => {
+      stopAutoPlay()
+    }
+  }, [previewModel, showPreview])
   useEffect(() => {
     return () => {
       if (autoPlayInterval) {

--- a/src/components/ModelPreview.jsx
+++ b/src/components/ModelPreview.jsx
@@ -52,7 +52,7 @@ export const ModelPreview = ({
       }}
       onWheel={onWheel}
       onMouseEnter={() => {setIsMouseOver(true); setIsHovering(true)}}
-      onMouseLeave={() => setIsMouseOver(false)}
+      onMouseLeave={() => {setIsMouseOver(false); setIsHovering(false)}}
     >
       <div className="relative w-full h-full">
         <Image


### PR DESCRIPTION
## Summary
- fix preview hover state handling
- auto-start autoplay when preview opens
- apply same logic for projects and logs pages

## Testing
- `npm install`
- `CI=1 npm run lint` *(fails: prompt for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68638aa214c4832ca02b3cd7a529411b