### PR TITLE
Add employee actions logging

### DIFF
--- a/src/app/api/employees/route.js
+++ b/src/app/api/employees/route.js
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcrypt'
+import { getUserFromSession } from '@/lib/auth'
+import { logEmployeeAction } from '@/lib/logger'
 
 
 export async function GET() {
@@ -72,6 +74,12 @@ export async function POST(request) {
         password: hashedPassword,
       },
     })
+
+    const user = await getUserFromSession()
+    await logEmployeeAction(
+      `Создан сотрудник: ${newEmployee.name} (${newEmployee.email})`,
+      user?.id || null
+    )
     
     // Не возвращаем пароль в ответе
     const { password: _, ...employeeWithoutPassword } = newEmployee

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -29,3 +29,19 @@ export async function logProjectAction(action, userId = null) {
     console.error('[Ошибка записи лога]', error)
   }
 }
+
+// Запись действий, связанных с сотрудниками. Используем общую таблицу логов
+// без привязки к модели, фиксируя только действие и пользователя.
+export async function logEmployeeAction(action, userId = null) {
+  try {
+    await prisma.log.create({
+      data: {
+        action,
+        userId,
+        modelId: null
+      }
+    })
+  } catch (error) {
+    console.error('[Ошибка записи лога]', error)
+  }
+}


### PR DESCRIPTION
## Summary
- record employee actions in logs
- add helper for employee logs

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68639a050140832cabf5249ddfc13fbb